### PR TITLE
Support default game name/pass/gs

### DIFF
--- a/BH/Modules/Bnet/Bnet.h
+++ b/BH/Modules/Bnet/Bnet.h
@@ -5,39 +5,48 @@
 struct Control;
 
 class Bnet : public Module {
-	private:
-		std::map<string, bool> bools;
-		bool* showLastGame;
-		bool* showLastPass;
-		bool* nextInstead;
-		bool* keepDesc;
-		static unsigned int failToJoin;
-		static std::string lastName;
-		static std::string lastPass;
-		static std::string lastDesc;
-		static std::regex reg;
+private:
+	std::map<string, bool> bools;
+	std::map<string, unsigned int> ints;
+	bool* showLastGame;
+	bool* showLastPass;
+	bool* nextInstead;
+	bool* keepDesc;
+	static string DefaultGame;
+	static string DefaultPassword;
+	static unsigned int failToJoin;
+	static std::string lastName;
+	static std::string lastPass;
+	static std::string lastDesc;
+	static std::regex reg;
+	unsigned int* defaultGsIndex;
+	static string defaultGsString;
 
-	public:
+public:
 
-		Bnet() : Module("Bnet") {};
+	Bnet() : Module("Bnet") {};
 
-		void OnLoad();
-		void OnUnload();
-		void LoadConfig();
+	void OnLoad();
+	void OnUnload();
+	void LoadConfig();
 
-		void OnGameJoin();
-		void OnGameExit();
+	void OnGameJoin();
+	void OnGameExit();
 
-		void InstallPatches();
-		void RemovePatches();
+	void InstallPatches();
+	void RemovePatches();
 
-		std::map<string, bool>* GetBools() { return &bools; }
-		static VOID __fastcall FOG10251Patch(DWORD lpCriticalSection, char nLine);
-		static DWORD __stdcall BnetLobbyAdBlockPatch(DWORD a1);
-		static VOID __fastcall NextGamePatch(Control* box, BOOL (__stdcall *FunCallBack)(Control*, DWORD, DWORD));
-		static VOID __fastcall NextPassPatch(Control* box, BOOL(__stdcall *FunCallBack)(Control*, DWORD, DWORD));
-		static VOID __fastcall GameDescPatch(Control* box, BOOL(__stdcall *FunCallBack)(Control*, DWORD, DWORD));
-		static void RemovePassPatch();
+	std::map<string, bool>* GetBools() { return &bools; }
+	static VOID __fastcall FOG10251Patch(DWORD lpCriticalSection, char nLine);
+	static DWORD __stdcall BnetLobbyAdBlockPatch(DWORD a1);
+	static VOID __fastcall NextGamePatch(Control* box, BOOL(__stdcall* FunCallBack)(Control*, DWORD, DWORD));
+	static VOID __fastcall NextPassPatch(Control* box, BOOL(__stdcall* FunCallBack)(Control*, DWORD, DWORD));
+	static VOID __fastcall GameDescPatch(Control* box, BOOL(__stdcall* FunCallBack)(Control*, DWORD, DWORD));
+	static void RemovePassPatch();
+
+	std::map<string, unsigned int>* GetInts() { return &ints; }
+	static std::string GetDefaultGamename() { return DefaultGame; }
+	static std::string GetDefaultPassword() { return DefaultPassword; }
 };
 
 void FailToJoin_Interception();


### PR DESCRIPTION
Add these lines to bh_settings.cfg to take effect

// This game name populates when you open d2, and is replaced by the last game name after 1st game Default Game Name: Vape Nation 420
// Leave blank for no password, replaced by your last password after 1st game Default Password:
// Default GS is a 0 based index so GS1 = 0, GS2 = 1, GS3 = 2, etc Default Gs: 2