### PR TITLE
[WIP] Add a score system for rare items

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -9,10 +9,13 @@ jobs:
 
     steps:
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x86
+        vs-version: '[16.4,16.5)'
     - uses: actions/checkout@master
     - name: MSBuild
-      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:CustomDefinitions=`"SHA=\`"($env:GITHUB_SHA.substring(0,7))\`"`" BH.sln
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
     - uses: actions/upload-artifact@v2
       with:
         name: BH.dll

--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -5,14 +5,13 @@ on: workflow_dispatch
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x86
-        vs-version: '[16.4,16.5)'
     - uses: actions/checkout@master
     - name: MSBuild
       run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,10 +11,13 @@ jobs:
 
     steps:
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x86
+        vs-version: '[16.4,16.5)'
     - uses: actions/checkout@master
     - name: MSBuild
-      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:CustomDefinitions=`"SHA=\`"($env:GITHUB_SHA.substring(0,7))\`"`" BH.sln
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
     - uses: actions/upload-artifact@v2
       with:
         name: BH.dll

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,14 +7,13 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x86
-        vs-version: '[16.4,16.5)'
     - uses: actions/checkout@master
     - name: MSBuild
       run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -50,6 +50,7 @@ struct UnitItemInfo {
 	UnitAny *item;
 	char itemCode[4];
 	ItemAttributes *attrs;
+	int score = 1;
 };
 
 // Item data obtained from an incoming 0x9c packet
@@ -117,6 +118,7 @@ struct ItemInfo {
 	std::vector<unsigned long> prefixes;
 	std::vector<unsigned long> suffixes;
 	std::vector<ItemProperty> properties;
+	int score = 1;
 	bool operator<(ItemInfo const & other) const;
 };
 
@@ -248,6 +250,27 @@ public:
 	PlayerTypeCondition(unsigned int m) : mode(m) { conditionType = CT_Operand; };
 private:
 	unsigned int mode;
+	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
+	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
+};
+
+class ScoreCondition : public Condition {
+public:
+	ScoreCondition(BYTE op, int value) : operation(op), score(value) { conditionType = CT_Operand; };
+private:
+	BYTE operation;
+	int score;
+	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
+	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
+};
+
+
+class AddScoreCondition : public Condition {
+public:
+	AddScoreCondition(BYTE op, int value) : termOrFactor(op), score(value) { conditionType = CT_Operand; };
+private:
+	BYTE termOrFactor;
+	int score;
 	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
 	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
 };

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -118,7 +118,6 @@ struct ItemInfo {
 	std::vector<unsigned long> prefixes;
 	std::vector<unsigned long> suffixes;
 	std::vector<ItemProperty> properties;
-	int score = 1;
 	bool operator<(ItemInfo const & other) const;
 };
 
@@ -259,17 +258,6 @@ public:
 	ScoreCondition(BYTE op, int value) : operation(op), score(value) { conditionType = CT_Operand; };
 private:
 	BYTE operation;
-	int score;
-	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
-	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
-};
-
-
-class AddScoreCondition : public Condition {
-public:
-	AddScoreCondition(BYTE op, int value) : termOrFactor(op), score(value) { conditionType = CT_Operand; };
-private:
-	BYTE termOrFactor;
 	int score;
 	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
 	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
@@ -625,6 +613,8 @@ struct Action {
 	int notifyColor;
 	bool noTracking;
 	unsigned int pingLevel;
+	int scoreOp = 0;
+	int score = 0;
 	Action() :
 		colorOnMap(UNDEFINED_COLOR),
 		borderColor(UNDEFINED_COLOR),
@@ -636,7 +626,8 @@ struct Action {
 		stopProcessing(true),
 		noTracking(false),
 		name(""),
-		description("") {}
+		description(""),
+		score(0){}
 };
 
 struct Rule {
@@ -696,6 +687,14 @@ struct Rule {
 		}
 		return retval;
 	}
+};
+
+class ItemScoreLookupCache : public RuleLookupCache<int> {
+	int make_cached_T(UnitItemInfo* uInfo) override;
+
+public:
+	ItemScoreLookupCache(const std::vector<Rule*>& RuleList) :
+		RuleLookupCache<int>(RuleList) {}
 };
 
 class ItemDescLookupCache : public RuleLookupCache<string> {
@@ -758,6 +757,7 @@ void BuildAction(string *str, Action *act);
 string ParseDescription(Action *act);
 int ParsePingLevel(Action *act, const string& reg_string);
 int ParseMapColor(Action *act, const string& reg_string);
+int ParseScore(Action* act, const string& key_string);
 void HandleUnknownItemCode(char *code, char *tag);
 BYTE GetOperation(string *op);
 inline bool IntegerCompare(unsigned int Lvalue, int operation, unsigned int Rvalue);


### PR DESCRIPTION
This hasn't really been tested at all (lewd is planning on testing it) but if anyone wanted to try it out, I figured I'd make a pull request. It allows you to filter items based on a "score" you create for the item. Score start at `1` and can be manipulated with `+-*/` i.e.

```
ItemDisplay[RING FCR>1 SCORE*3]: %CONTINUE%
ItemDisplay[RING STR>1 SCORE+5]: %CONTINUE%
ItemDisplay[RING FRES>1 SCORE+10]: %CONTINUE%
ItemDisplay[RING CRES>1 SCORE+5]: %CONTINUE%
ItemDisplay[RING LRES>1 SCORE-5]: %CONTINUE%
ItemDisplay[SCORE>10]: %SCORE%%NAME%
```

The above example was just thrown together and isn't really good, but for instance if you found a ring w/ FCR, STR, and FRES then the score would be 18 and it would be kept by the last line in the filter. Figure this could be yet another way to filter rare items to decide which are good.